### PR TITLE
Add option to also show available resources

### DIFF
--- a/BetterCostStrings/Config/XComBetterCostStrings_Defaults.ini
+++ b/BetterCostStrings/Config/XComBetterCostStrings_Defaults.ini
@@ -1,3 +1,4 @@
 [BetterCostStrings.BetterCostStrings_Settings_Defaults]
 CONFIG_VERSION=1
 ENABLE_HIGHLIGHT_SPARSE=true
+SHOW_AVAILABLE_RESOURCES=false

--- a/BetterCostStrings/README.md
+++ b/BetterCostStrings/README.md
@@ -1,7 +1,7 @@
 ﻿# Better Cost Strings
 
-XCOM 2 mod that shows inventory counts and colour-codes entries in cost strings when building
-items, starting research, etc.
+XCOM 2 mod that shows inventory counts and highlights sparse artifacts and resources in cost strings
+when building items, starting research, etc.
 
 ## Compatibility
 

--- a/BetterCostStrings/Src/BetterCostStrings/Classes/BetterCostStrings_Settings.uc
+++ b/BetterCostStrings/Src/BetterCostStrings/Classes/BetterCostStrings_Settings.uc
@@ -10,6 +10,9 @@ var config int CONFIG_VERSION;
 // BCS-1: Config variable to enable highlighting of sparse resources
 var config bool ENABLE_HIGHLIGHT_SPARSE;
 
+// BCS-3: Config variable to display available resources (Supplies, Elerium Crystals, etc.)
+var config bool SHOW_AVAILABLE_RESOURCES;
+
 `MCM_CH_VersionChecker(class'BetterCostStrings_Settings_Defaults'.default.CONFIG_VERSION, CONFIG_VERSION)
 
 event OnInit(UIScreen Screen)
@@ -45,14 +48,23 @@ simulated function ClientModCallback(MCM_API_Instance ConfigAPI, int GameMode)
         ENABLE_HIGHLIGHT_SPARSE,
         HighlightSparseSaveHandler);
 
+    // BCS-3
+    group.AddCheckBox('showAvailableResources',
+        "Also show available resources (Supplies, Elerium Crystals, etc.)",
+        "If activated, also shows available resources like Supplies, Elerium Crystal, Elerium Cores, etc. in the cost string.",
+        SHOW_AVAILABLE_RESOURCES,
+        ShowAvailableResourcesSaveHandler);
+
     page.ShowSettings();
 }
 
 `MCM_API_BasicCheckboxSaveHandler(HighlightSparseSaveHandler, ENABLE_HIGHLIGHT_SPARSE)
+`MCM_API_BasicCheckboxSaveHandler(ShowAvailableResourcesSaveHandler, SHOW_AVAILABLE_RESOURCES)
 
 simulated function LoadSavedSettings()
 {
     ENABLE_HIGHLIGHT_SPARSE = `MCM_CH_GetValue(class'BetterCostStrings_Settings_Defaults'.default.ENABLE_HIGHLIGHT_SPARSE, ENABLE_HIGHLIGHT_SPARSE);
+    SHOW_AVAILABLE_RESOURCES = `MCM_CH_GetValue(class'BetterCostStrings_Settings_Defaults'.default.SHOW_AVAILABLE_RESOURCES, SHOW_AVAILABLE_RESOURCES);
 }
 
 function SaveButtonClicked(MCM_API_SettingsPage Page)

--- a/BetterCostStrings/Src/BetterCostStrings/Classes/BetterCostStrings_Settings_Defaults.uc
+++ b/BetterCostStrings/Src/BetterCostStrings/Classes/BetterCostStrings_Settings_Defaults.uc
@@ -5,3 +5,6 @@ var config int CONFIG_VERSION;
 
 // BCS-1: Config variable to enable highlighting of sparse resources
 var config bool ENABLE_HIGHLIGHT_SPARSE;
+
+// BCS-3: Config variable to display available resources (Supplies, Elerium Crystals, etc.)
+var config bool SHOW_AVAILABLE_RESOURCES;

--- a/BetterCostStrings/Src/BetterCostStrings/Classes/UIUtilities_Strategy_BCS.uc
+++ b/BetterCostStrings/Src/BetterCostStrings/Classes/UIUtilities_Strategy_BCS.uc
@@ -10,10 +10,16 @@ static function bool ShouldHighlightSparseResource()
 	return `MCM_CH_GetValue(class'BetterCostStrings_Settings_Defaults'.default.ENABLE_HIGHLIGHT_SPARSE, class'BetterCostStrings_Settings'.default.ENABLE_HIGHLIGHT_SPARSE);
 }
 
+// BCS-3
+static function bool ShouldShowAvailableResources()
+{
+	return `MCM_CH_GetValue(class'BetterCostStrings_Settings_Defaults'.default.SHOW_AVAILABLE_RESOURCES, class'BetterCostStrings_Settings'.default.SHOW_AVAILABLE_RESOURCES);
+}
+
 static function String GetStrategyCostString(StrategyCost StratCost, array<StrategyCostScalar> CostScalars, optional float DiscountPercent)
 {
 	local int iResource, iArtifact, Quantity, Available;
-	local String strCost, strResourceCost, strArtifactCost, strResourcesRemaining;
+	local String strCost, strResourceCost, strArtifactCost, strArtifactsRemaining, strResourcesRemaining;
 	local StrategyCost ScaledStratCost;
 	local XComGameState_HeadquartersXCom XComHQ;
 
@@ -27,14 +33,14 @@ static function String GetStrategyCostString(StrategyCost StratCost, array<Strat
 		strArtifactCost = String(Quantity) @ GetResourceDisplayName(ScaledStratCost.ArtifactCosts[iArtifact].ItemTemplateName, Quantity);
 
 		Available = XComHQ.GetResourceAmount(ScaledStratCost.ArtifactCosts[iArtifact].ItemTemplateName);
-		strResourcesRemaining = "(" $ String(Available) $ ")";
+		strArtifactsRemaining = "(" $ String(Available) $ ")";
 
 		if (!XComHQ.CanAffordResourceCost(ScaledStratCost.ArtifactCosts[iArtifact].ItemTemplateName, ScaledStratCost.ArtifactCosts[iArtifact].Quantity))
 		{
 			strArtifactCost = class'UIUtilities_Text'.static.GetColoredText(strArtifactCost, eUIState_Bad);
 			if (Available > 0)
 			{
-				strArtifactCost @= class'UIUtilities_Text'.static.GetColoredText(strResourcesRemaining, eUIState_Bad);
+				strArtifactCost @= class'UIUtilities_Text'.static.GetColoredText(strArtifactsRemaining, eUIState_Bad);
 			}
 		}
 		else
@@ -42,11 +48,11 @@ static function String GetStrategyCostString(StrategyCost StratCost, array<Strat
 			if (ShouldHighlightSparseResource() && Available < 2 * Quantity)
 			{
 				strArtifactCost = class'UIUtilities_Text'.static.GetColoredText(strArtifactCost, eUIState_Warning);
-				strArtifactCost @= class'UIUtilities_Text'.static.GetColoredText(strResourcesRemaining, eUIState_Warning);
+				strArtifactCost @= class'UIUtilities_Text'.static.GetColoredText(strArtifactsRemaining, eUIState_Warning);
 			}
 			else {
 				strArtifactCost = class'UIUtilities_Text'.static.GetColoredText(strArtifactCost, eUIState_Good);
-				strArtifactCost @= class'UIUtilities_Text'.static.GetColoredText(strResourcesRemaining, eUIState_Good);
+				strArtifactCost @= class'UIUtilities_Text'.static.GetColoredText(strArtifactsRemaining, eUIState_Good);
 			}
 		}
 
@@ -75,19 +81,31 @@ static function String GetStrategyCostString(StrategyCost StratCost, array<Strat
 		strResourceCost = String(Quantity) @ GetResourceDisplayName(ScaledStratCost.ResourceCosts[iResource].ItemTemplateName, Quantity);
 
 		Available = XComHQ.GetResourceAmount(ScaledStratCost.ResourceCosts[iResource].ItemTemplateName);
+		strResourcesRemaining = "(" $ String(Available) $ ")";
 
 		if (!XComHQ.CanAffordResourceCost(ScaledStratCost.ResourceCosts[iResource].ItemTemplateName, ScaledStratCost.ResourceCosts[iResource].Quantity))
 		{
-			strResourceCost = class'UIUtilities_Text'.static.GetColoredText(strResourceCost, eUIState_Bad);
+			if (ShouldShowAvailableResources() && Available > 0)
+			{
+				strResourceCost @= class'UIUtilities_Text'.static.GetColoredText(strResourcesRemaining, eUIState_Bad);
+			}
 		}
 		else
 		{
 			if (ShouldHighlightSparseResource() && Available < 2 * Quantity)
 			{
 				strResourceCost = class'UIUtilities_Text'.static.GetColoredText(strResourceCost, eUIState_Warning);
+				if (ShouldShowAvailableResources())
+				{
+					strResourceCost @= class'UIUtilities_Text'.static.GetColoredText(strResourcesRemaining, eUIState_Warning);
+				}
 			}
 			else {
 				strResourceCost = class'UIUtilities_Text'.static.GetColoredText(strResourceCost, eUIState_Good);
+				if (ShouldShowAvailableResources())
+				{
+					strResourceCost @= class'UIUtilities_Text'.static.GetColoredText(strResourcesRemaining, eUIState_Good);
+				}
 			}
 
 		}

--- a/BetterCostStringsWotC/Config/XComBetterCostStrings_Defaults.ini
+++ b/BetterCostStringsWotC/Config/XComBetterCostStrings_Defaults.ini
@@ -1,3 +1,4 @@
 [BetterCostStringsWotC.BetterCostStrings_Settings_Defaults]
 CONFIG_VERSION=1
 ENABLE_HIGHLIGHT_SPARSE=true
+SHOW_AVAILABLE_RESOURCES=false

--- a/BetterCostStringsWotC/README.md
+++ b/BetterCostStringsWotC/README.md
@@ -1,7 +1,7 @@
 ﻿# Better Cost Strings
 
-XCOM 2 mod that shows inventory counts and colour-codes entries in cost strings when building
-items, starting research, etc.
+XCOM 2 mod that shows inventory counts and highlights sparse artifacts and resources in cost strings
+when building items, starting research, etc.
 
 ## Compatibility
 

--- a/BetterCostStringsWotC/Src/BetterCostStringsWotC/Classes/BetterCostStrings_Settings.uc
+++ b/BetterCostStringsWotC/Src/BetterCostStringsWotC/Classes/BetterCostStrings_Settings.uc
@@ -10,6 +10,9 @@ var config int CONFIG_VERSION;
 // BCS-1: Config variable to enable highlighting of sparse resources
 var config bool ENABLE_HIGHLIGHT_SPARSE;
 
+// BCS-3: Config variable to display available resources (Supplies, Elerium Crystals, etc.)
+var config bool SHOW_AVAILABLE_RESOURCES;
+
 `MCM_CH_VersionChecker(class'BetterCostStrings_Settings_Defaults'.default.CONFIG_VERSION, CONFIG_VERSION)
 
 event OnInit(UIScreen Screen)
@@ -45,14 +48,23 @@ simulated function ClientModCallback(MCM_API_Instance ConfigAPI, int GameMode)
         ENABLE_HIGHLIGHT_SPARSE,
         HighlightSparseSaveHandler);
 
+    // BCS-3
+    group.AddCheckBox('showAvailableResources',
+        "Also show available resources (Supplies, Elerium Crystals, etc.)",
+        "If activated, also shows available resources like Supplies, Elerium Crystal, Elerium Cores, etc. in the cost string.",
+        SHOW_AVAILABLE_RESOURCES,
+        ShowAvailableResourcesSaveHandler);
+
     page.ShowSettings();
 }
 
 `MCM_API_BasicCheckboxSaveHandler(HighlightSparseSaveHandler, ENABLE_HIGHLIGHT_SPARSE)
+`MCM_API_BasicCheckboxSaveHandler(ShowAvailableResourcesSaveHandler, SHOW_AVAILABLE_RESOURCES)
 
 simulated function LoadSavedSettings()
 {
     ENABLE_HIGHLIGHT_SPARSE = `MCM_CH_GetValue(class'BetterCostStrings_Settings_Defaults'.default.ENABLE_HIGHLIGHT_SPARSE, ENABLE_HIGHLIGHT_SPARSE);
+    SHOW_AVAILABLE_RESOURCES = `MCM_CH_GetValue(class'BetterCostStrings_Settings_Defaults'.default.SHOW_AVAILABLE_RESOURCES, SHOW_AVAILABLE_RESOURCES);
 }
 
 function SaveButtonClicked(MCM_API_SettingsPage Page)

--- a/BetterCostStringsWotC/Src/BetterCostStringsWotC/Classes/BetterCostStrings_Settings_Defaults.uc
+++ b/BetterCostStringsWotC/Src/BetterCostStringsWotC/Classes/BetterCostStrings_Settings_Defaults.uc
@@ -5,3 +5,6 @@ var config int CONFIG_VERSION;
 
 // BCS-1: Config variable to enable highlighting of sparse resources
 var config bool ENABLE_HIGHLIGHT_SPARSE;
+
+// BCS-3: Config variable to display available resources (Supplies, Elerium Crystals, etc.)
+var config bool SHOW_AVAILABLE_RESOURCES;

--- a/BetterCostStringsWotC/Src/BetterCostStringsWotC/Classes/UIUtilities_Strategy_BCS.uc
+++ b/BetterCostStringsWotC/Src/BetterCostStringsWotC/Classes/UIUtilities_Strategy_BCS.uc
@@ -10,10 +10,16 @@ static function bool ShouldHighlightSparseResource()
 	return `MCM_CH_GetValue(class'BetterCostStrings_Settings_Defaults'.default.ENABLE_HIGHLIGHT_SPARSE, class'BetterCostStrings_Settings'.default.ENABLE_HIGHLIGHT_SPARSE);
 }
 
+// BCS-3
+static function bool ShouldShowAvailableResources()
+{
+	return `MCM_CH_GetValue(class'BetterCostStrings_Settings_Defaults'.default.SHOW_AVAILABLE_RESOURCES, class'BetterCostStrings_Settings'.default.SHOW_AVAILABLE_RESOURCES);
+}
+
 static function String GetStrategyCostString(StrategyCost StratCost, array<StrategyCostScalar> CostScalars, optional float DiscountPercent)
 {
 	local int iResource, iArtifact, Quantity, Available;
-	local String strCost, strResourceCost, strArtifactCost, strResourcesRemaining;
+	local String strCost, strResourceCost, strArtifactCost, strArtifactsRemaining, strResourcesRemaining;
 	local StrategyCost ScaledStratCost;
 	local XComGameState_HeadquartersXCom XComHQ;
 
@@ -27,14 +33,14 @@ static function String GetStrategyCostString(StrategyCost StratCost, array<Strat
 		strArtifactCost = String(Quantity) @ GetResourceDisplayName(ScaledStratCost.ArtifactCosts[iArtifact].ItemTemplateName, Quantity);
 
 		Available = XComHQ.GetResourceAmount(ScaledStratCost.ArtifactCosts[iArtifact].ItemTemplateName);
-		strResourcesRemaining = "(" $ String(Available) $ ")";
+		strArtifactsRemaining = "(" $ String(Available) $ ")";
 
 		if (!XComHQ.CanAffordResourceCost(ScaledStratCost.ArtifactCosts[iArtifact].ItemTemplateName, ScaledStratCost.ArtifactCosts[iArtifact].Quantity))
 		{
 			strArtifactCost = class'UIUtilities_Text'.static.GetColoredText(strArtifactCost, eUIState_Bad);
 			if (Available > 0)
 			{
-				strArtifactCost @= class'UIUtilities_Text'.static.GetColoredText(strResourcesRemaining, eUIState_Bad);
+				strArtifactCost @= class'UIUtilities_Text'.static.GetColoredText(strArtifactsRemaining, eUIState_Bad);
 			}
 		}
 		else
@@ -42,11 +48,11 @@ static function String GetStrategyCostString(StrategyCost StratCost, array<Strat
 			if (ShouldHighlightSparseResource() && Available < 2 * Quantity)
 			{
 				strArtifactCost = class'UIUtilities_Text'.static.GetColoredText(strArtifactCost, eUIState_Warning);
-				strArtifactCost @= class'UIUtilities_Text'.static.GetColoredText(strResourcesRemaining, eUIState_Warning);
+				strArtifactCost @= class'UIUtilities_Text'.static.GetColoredText(strArtifactsRemaining, eUIState_Warning);
 			}
 			else {
 				strArtifactCost = class'UIUtilities_Text'.static.GetColoredText(strArtifactCost, eUIState_Good);
-				strArtifactCost @= class'UIUtilities_Text'.static.GetColoredText(strResourcesRemaining, eUIState_Good);
+				strArtifactCost @= class'UIUtilities_Text'.static.GetColoredText(strArtifactsRemaining, eUIState_Good);
 			}
 		}
 
@@ -75,19 +81,32 @@ static function String GetStrategyCostString(StrategyCost StratCost, array<Strat
 		strResourceCost = String(Quantity) @ GetResourceDisplayName(ScaledStratCost.ResourceCosts[iResource].ItemTemplateName, Quantity);
 
 		Available = XComHQ.GetResourceAmount(ScaledStratCost.ResourceCosts[iResource].ItemTemplateName);
+		strResourcesRemaining = "(" $ String(Available) $ ")";
 
 		if (!XComHQ.CanAffordResourceCost(ScaledStratCost.ResourceCosts[iResource].ItemTemplateName, ScaledStratCost.ResourceCosts[iResource].Quantity))
 		{
 			strResourceCost = class'UIUtilities_Text'.static.GetColoredText(strResourceCost, eUIState_Bad);
+			if (ShouldShowAvailableResources() && Available > 0)
+			{
+				strResourceCost @= class'UIUtilities_Text'.static.GetColoredText(strResourcesRemaining, eUIState_Bad);
+			}
 		}
 		else
 		{
 			if (ShouldHighlightSparseResource() && Available < 2 * Quantity)
 			{
 				strResourceCost = class'UIUtilities_Text'.static.GetColoredText(strResourceCost, eUIState_Warning);
+				if (ShouldShowAvailableResources())
+				{
+					strResourceCost @= class'UIUtilities_Text'.static.GetColoredText(strResourcesRemaining, eUIState_Warning);
+				}
 			}
 			else {
 				strResourceCost = class'UIUtilities_Text'.static.GetColoredText(strResourceCost, eUIState_Good);
+				if (ShouldShowAvailableResources())
+				{
+					strResourceCost @= class'UIUtilities_Text'.static.GetColoredText(strResourcesRemaining, eUIState_Good);
+				}
 			}
 
 		}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ﻿# Better Cost Strings
 
-XCOM 2 mod that shows inventory counts and colour-codes entries in cost strings when building
-items, starting research, etc.
+XCOM 2 mod that shows inventory counts and highlights sparse artifacts and resources in cost strings
+when building items, starting research, etc.
 
 ## Compatibility
 


### PR DESCRIPTION
Adds a config option to also show available resources (e.g. Supplies) in addition to available artifacts (e.g. corpses). Also cleans up the language regarding artifacts and resources in the READMEs.