### PR TITLE
Fix crashes caused by MCM Settings screen acting as a ScreenListener

### DIFF
--- a/BetterCostStrings/Src/BetterCostStrings/Classes/BetterCostStrings_MCM_ScreenListener.uc
+++ b/BetterCostStrings/Src/BetterCostStrings/Classes/BetterCostStrings_MCM_ScreenListener.uc
@@ -1,0 +1,27 @@
+class BetterCostStrings_MCM_ScreenListener extends UIScreenListener;
+
+event OnInit (UIScreen Screen)
+{
+	local BetterCostStrings_Settings MCMScreen;
+
+	if (ScreenClass == none)
+	{
+		if (MCM_API(Screen) != none)
+		{
+			ScreenClass = Screen.Class;
+		}
+		else
+		{
+			return;
+		}
+	}
+
+	MCMScreen = new class'BetterCostStrings_Settings';
+	MCMScreen.OnInit(Screen);
+}
+
+defaultproperties
+{
+    ScreenClass = none;
+}
+

--- a/BetterCostStrings/Src/BetterCostStrings/Classes/BetterCostStrings_Settings.uc
+++ b/BetterCostStrings/Src/BetterCostStrings/Classes/BetterCostStrings_Settings.uc
@@ -3,7 +3,7 @@ class BetterCostStrings_Settings extends UIScreenListener config(BetterCostStrin
 // Mod version
 const VERSION_MAJOR = 1;
 const VERSION_MINOR = 2;
-const VERSION_PATCH = 0;
+const VERSION_PATCH = 1;
 
 // Config version
 var config int CONFIG_VERSION;

--- a/BetterCostStrings/Src/BetterCostStrings/Classes/BetterCostStrings_Settings.uc
+++ b/BetterCostStrings/Src/BetterCostStrings/Classes/BetterCostStrings_Settings.uc
@@ -1,4 +1,4 @@
-class BetterCostStrings_Settings extends UIScreenListener config(BetterCostStrings_Settings);
+class BetterCostStrings_Settings extends Object config(BetterCostStrings_Settings);
 
 // Mod version
 const VERSION_MAJOR = 1;

--- a/BetterCostStringsWotC/Src/BetterCostStringsWotC/Classes/BetterCostStrings_MCM_ScreenListener.uc
+++ b/BetterCostStringsWotC/Src/BetterCostStringsWotC/Classes/BetterCostStrings_MCM_ScreenListener.uc
@@ -1,0 +1,27 @@
+class BetterCostStrings_MCM_ScreenListener extends UIScreenListener;
+
+event OnInit (UIScreen Screen)
+{
+	local BetterCostStrings_Settings MCMScreen;
+
+	if (ScreenClass == none)
+	{
+		if (MCM_API(Screen) != none)
+		{
+			ScreenClass = Screen.Class;
+		}
+		else
+		{
+			return;
+		}
+	}
+
+	MCMScreen = new class'BetterCostStrings_Settings';
+	MCMScreen.OnInit(Screen);
+}
+
+defaultproperties
+{
+    ScreenClass = none;
+}
+

--- a/BetterCostStringsWotC/Src/BetterCostStringsWotC/Classes/BetterCostStrings_Settings.uc
+++ b/BetterCostStringsWotC/Src/BetterCostStringsWotC/Classes/BetterCostStrings_Settings.uc
@@ -3,7 +3,7 @@ class BetterCostStrings_Settings extends UIScreenListener config(BetterCostStrin
 // Mod version
 const VERSION_MAJOR = 1;
 const VERSION_MINOR = 2;
-const VERSION_PATCH = 0;
+const VERSION_PATCH = 1;
 
 // Config version
 var config int CONFIG_VERSION;

--- a/BetterCostStringsWotC/Src/BetterCostStringsWotC/Classes/BetterCostStrings_Settings.uc
+++ b/BetterCostStringsWotC/Src/BetterCostStringsWotC/Classes/BetterCostStrings_Settings.uc
@@ -1,4 +1,4 @@
-class BetterCostStrings_Settings extends UIScreenListener config(BetterCostStrings_Settings);
+class BetterCostStrings_Settings extends Object config(BetterCostStrings_Settings);
 
 // Mod version
 const VERSION_MAJOR = 1;


### PR DESCRIPTION
Closes #9 